### PR TITLE
feat: add metadata and sitemap configuration

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: 'https://example.com',
+  generateRobotsTxt: true,
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
     "react": "19.1.0",
@@ -22,6 +23,7 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "next-sitemap": "^4.3.1"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://example.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+</urlset>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,51 @@
 import Image from "next/image";
+import Script from "next/script";
+import type { Metadata } from "next";
+
+export const generateMetadata = (): Metadata => {
+  const title = "Lior Medan - Developer";
+  const description = "Personal developer page";
+  const url = "https://example.com";
+  const imageUrl = `${url}/next.svg`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: title,
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+      locale: "en_US",
+      type: "website",
+    },
+  };
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Lior Medan - Developer",
+  url: "https://example.com",
+};
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+    <>
+      <Script
+        id="json-ld-home"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"
@@ -99,5 +142,6 @@ export default function Home() {
         </a>
       </footer>
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add generateMetadata and JSON-LD on home page
- configure next-sitemap and include sitemap and robots files

## Testing
- `pnpm lint`
- `pnpm build` *(fails: next-sitemap: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c48df82f38832cbdb47d23328e5e9c