### PR TITLE
feat: add 3D hero with react-three

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "next": "15.5.2",
+    "@react-three/fiber": "^8.15.16",
+    "@react-three/drei": "^9.103.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import Image from "next/image";
+import ThreeHero from "../components/ThreeHero";
 
 export default function Home() {
   return (
     <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+        <ThreeHero />
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/src/components/ThreeHero.tsx
+++ b/src/components/ThreeHero.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import { useRef } from 'react';
+import type { Mesh } from 'three';
+
+function RotatingBox() {
+  const meshRef = useRef<Mesh>(null);
+  useFrame(() => {
+    if (meshRef.current) {
+      meshRef.current.rotation.x += 0.01;
+      meshRef.current.rotation.y += 0.01;
+    }
+  });
+  return (
+    <mesh ref={meshRef}>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color="orange" />
+    </mesh>
+  );
+}
+
+export default function ThreeHero() {
+  return (
+    <div className="w-full h-64">
+      <Canvas>
+        <ambientLight />
+        <pointLight position={[10, 10, 10]} />
+        <RotatingBox />
+        <OrbitControls />
+      </Canvas>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add @react-three/fiber and @react-three/drei dependencies
- create ThreeHero component with simple rotating cube
- display ThreeHero on the home page

## Testing
- ⚠️ `pnpm install` (403 Forbidden fetching @react-three/drei)
- ✅ `pnpm lint`
- ⚠️ `pnpm build` (module not found: @react-three/drei)


------
https://chatgpt.com/codex/tasks/task_e_68c48de1bb24832cb2d76304c1fe44a2